### PR TITLE
added support for live migrations using dual primary mode

### DIFF
--- a/qemu
+++ b/qemu
@@ -44,6 +44,19 @@ function setRole() {
   exit 1
 }
 
+function setDualPrimary() {
+  yesno=$1
+  resourceName=$(echo $2 | sed -e 's|^dev="/dev/drbd/by-res/\(.*\)"|\1|');
+  for i in $(seq $MAX_ATTEMPTS); do
+    #echo "attempt $i: drbdadm net-options --allow-two-primaries=$yesno $resourceName" >>/var/log/libvirt/hook-qemu.log
+    /sbin/drbdadm net-options --allow-two-primaries=$yesno $resourceName && return;
+    sleep $SLEEP_BETWEEN_ATTEMPTS;
+  done
+  echo "$MAX_ATTEMPTS attempts executing \"drbdadm net-options --allow-two-primaries=$yesno $resourceName failed, giving up.\""  >&2
+  exit 1
+}
+
+
 trap cleanup EXIT
 
 if [ "$#" -ne 4 ]; then
@@ -58,6 +71,16 @@ task=$2
 guest_cfg=`mktemp`
 
 case "$task" in
+migrate)
+  # "qemu <guest> migrate", means that libvirt is preparing to migrate the guest to this host
+  
+  # Read XML configuration on stdin.
+  cat - > $guest_cfg
+
+  for dev in $(selectDrbdDevices $guest_cfg); do
+    setDualPrimary "yes" $dev;
+  done
+  ;;
 prepare)
   # "qemu <guest> prepare", means that libvirt is preparing to start the guest.
 
@@ -76,6 +99,7 @@ release)
 
   for dev in $(selectDrbdDevices $guest_cfg); do
     setRole secondary $dev;
+    setDualPrimary "no" $dev;
   done
   ;;
 esac


### PR DESCRIPTION
Some output from this being used in testing:

[root@kvm5 ~]# drbdadm status testvm
testvm role:Primary
  disk:UpToDate
  kvm6 role:Secondary
    peer-disk:UpToDate

[root@kvm5 ~]# virsh migrate --live testvm qemu+ssh://kvm6.loosefoot.com/system

[root@kvm5 ~]# drbdadm status testvm
testvm role:Secondary
  disk:UpToDate
  kvm6 role:Primary
    peer-disk:UpToDate

[root@kvm5 ~]# drbdadm primary testvm
testvm: State change failed: (-1) Multiple primaries not allowed by config
Command 'drbdsetup primary testvm' terminated with exit code 11

The last one just shows that normally you can't set primary mode unless dual primary is turned on.